### PR TITLE
Updates the kube2sky, hyperkube and etcd dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Kubernetes binaries besides what's provided in this repository.
 
 For the skydns availability check you additionally need ``nslookup``.
 
-The script was tested with Ubuntu 14.10 and Docker 1.6.2.
+The script was tested with Ubuntu 14.10, Mint 17.1 ('Rebecca') as well as with Docker 1.6.2 and Docker 1.7.0
 
 ## Example
 To fire up a single-node Kubernetes cluster on your local machine all you need to do is call the ``kube-up.sh`` script:
@@ -84,9 +84,7 @@ Commercial support is available at
 </html>
 ```
 ## Kubernetes version
-Unfortunately this example is currently not working with Kubernetes
-0.15.0 due to a port change which prevents the kubelet from talking to
-the master. Thus the previous release (0.14.2) is used.
+The example currently uses Kubernetes 18.2.
 
 ## References
 - This script is based on the instructions in the [Running kubernetes locally via Docker](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/getting-started-guides/docker.md) article.

--- a/kube-dns.rc.yaml
+++ b/kube-dns.rc.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: gcr.io/google_containers/etcd:2.0.9
+        image: gcr.io/google_containers/etcd:2.0.12
         command:
         - /usr/local/bin/etcd
         - -listen-client-urls
@@ -30,7 +30,7 @@ spec:
         - -initial-cluster-token
         - skydns-etcd
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.7
+        image: gcr.io/google_containers/kube2sky:1.9
         args:
         # command = "/kube2sky"
         - -domain=kubernetes.local

--- a/kube-up.sh
+++ b/kube-up.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-IMG_K8SETCD=gcr.io/google_containers/etcd:2.0.9
-IMG_HYPERKUBE=gcr.io/google_containers/hyperkube:v0.17.0
-IMG_SKYETCD=quay.io/coreos/etcd:v2.0.9
-IMG_KUBE2SKY=gcr.io/google_containers/kube2sky:1.7
+IMG_K8SETCD=gcr.io/google_containers/etcd:2.0.12
+IMG_HYPERKUBE=gcr.io/google_containers/hyperkube:v0.18.2
+IMG_SKYETCD=quay.io/coreos/etcd:v2.0.12
+IMG_KUBE2SKY=gcr.io/google_containers/kube2sky:1.9
 IMG_SKYDNS=gcr.io/google_containers/skydns:2015-03-11-001
 
 echo "Pulling images..."


### PR DESCRIPTION
The new version of kube2sky is now 1.9.
Bumps etcd to version 2.0.12.
Also hyperkube is updated to version 0.18.2.

Adjusts the README.md file.